### PR TITLE
ensure the produced files are system-independent, fix locations ordering and tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys._
 
 name := "scalingua-root"
-version := "0.7.2"
+version := "0.7.3-SNAPSHOT"
 crossPaths := true
 
 publishArtifact := false

--- a/sbt-plugin/src/main/scala/ru/makkarpov/scalingua/plugin/PoCompiler.scala
+++ b/sbt-plugin/src/main/scala/ru/makkarpov/scalingua/plugin/PoCompiler.scala
@@ -18,13 +18,13 @@ package ru.makkarpov.scalingua.plugin
 
 import java.io._
 import java.nio.charset.StandardCharsets
-import java_cup.runtime.ComplexSymbolFactory.Location
 
+import java_cup.runtime.ComplexSymbolFactory.Location
 import ru.makkarpov.scalingua.LanguageId
 import ru.makkarpov.scalingua.extract.TaggedParser
 import ru.makkarpov.scalingua.plural.ParsedPlural
 import ru.makkarpov.scalingua.pofile.parse.{LexerException, ParserException}
-import ru.makkarpov.scalingua.pofile.{Message, MultipartString, PoFile}
+import ru.makkarpov.scalingua.pofile.{Message, MultipartString, NewLinePrintWriter, PoFile}
 
 object PoCompiler {
   val EndOfFile     = 0
@@ -161,7 +161,7 @@ object PoCompiler {
       case Some(x) => ParsedPlural.fromHeader(x)
     }
 
-    val pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(ctx.target), StandardCharsets.UTF_8), false)
+    val pw = new NewLinePrintWriter(new OutputStreamWriter(new FileOutputStream(ctx.target), StandardCharsets.UTF_8), false)
     try {
       pw.print(
         s"""${GenerationContext.ScalaHashPrefix}${ctx.srcHash}
@@ -188,7 +188,7 @@ object PoCompiler {
   }
 
   def generateIndex(pkg: String, tgt: File, langs: Seq[LanguageId], hasTags: Boolean): Unit = {
-    val pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(tgt), StandardCharsets.UTF_8), false)
+    val pw = new NewLinePrintWriter(new OutputStreamWriter(new FileOutputStream(tgt), StandardCharsets.UTF_8), false)
     try {
       pw.print(
         s"""${if (pkg.nonEmpty) s"package $pkg" else ""}
@@ -235,7 +235,7 @@ object PoCompiler {
     if (ctx.checkTextHash)
       return
 
-    val pw = new PrintWriter(new OutputStreamWriter(new FileOutputStream(ctx.target), StandardCharsets.UTF_8), false)
+    val pw = new NewLinePrintWriter(new OutputStreamWriter(new FileOutputStream(ctx.target), StandardCharsets.UTF_8), false)
     try {
       pw.print(
         s"""${GenerationContext.ScalaHashPrefix}${ctx.srcHash}

--- a/sbt-plugin/src/sbt-test/main/no-escape-unicode/test
+++ b/sbt-plugin/src/sbt-test/main/no-escape-unicode/test
@@ -1,3 +1,3 @@
 > test
 $ exec chmod +x verify-pot.sh
-$ exec ./verify-pot.sh
+$ exec bash ./verify-pot.sh

--- a/sbt-plugin/src/sbt-test/main/simple-lang/messages.pot
+++ b/sbt-plugin/src/sbt-test/main/simple-lang/messages.pot
@@ -1,16 +1,16 @@
 
+#: src/test/scala/Test.scala:12
 #: src/test/scala/Test.scala:19
 #: src/test/scala/Test.scala:26
-#: src/test/scala/Test.scala:12
 #: src/test/scala/Test.scala:33
 #: src/test/scala/Test.scala:40
 msgid "Hello, world!"
 msgstr ""
 
 #: src/test/scala/Test.scala:13
+#: src/test/scala/Test.scala:20
 #: src/test/scala/Test.scala:27
 #: src/test/scala/Test.scala:34
-#: src/test/scala/Test.scala:20
 #: src/test/scala/Test.scala:41
 msgid "There is %(n) dog!"
 msgid_plural "There is %(n) dogs!"

--- a/sbt-plugin/src/sbt-test/main/simple-lang/test
+++ b/sbt-plugin/src/sbt-test/main/simple-lang/test
@@ -1,3 +1,3 @@
 > test
 $ exec chmod +x verify-pot.sh
-$ exec ./verify-pot.sh
+$ exec bash ./verify-pot.sh

--- a/sbt-plugin/src/sbt-test/main/tagged-strings/test
+++ b/sbt-plugin/src/sbt-test/main/tagged-strings/test
@@ -1,3 +1,3 @@
 > test
 $ exec chmod +x verify-pot.sh
-$ exec ./verify-pot.sh
+$ exec bash ./verify-pot.sh

--- a/scalingua/src/main/scala/ru/makkarpov/scalingua/extract/ExtractorSettings.scala
+++ b/scalingua/src/main/scala/ru/makkarpov/scalingua/extract/ExtractorSettings.scala
@@ -39,11 +39,11 @@ object ExtractorSettings {
     val implicitContext = setts.get("implicitContext").filter(_.nonEmpty)
     val escapeUnicode = setts.get("escapeUnicode").exists(_ == "true")
 
-    ExtractorSettings(enable, baseDir, targetFile, implicitContext, taggedFile, escapeUnicode)
+    ExtractorSettings(enable, new File(baseDir), targetFile, implicitContext, taggedFile, escapeUnicode)
   }
 }
 
-case class ExtractorSettings(enable: Boolean, srcBaseDir: String, targetFile: File, implicitContext: Option[String],
+case class ExtractorSettings(enable: Boolean, srcBaseDir: File, targetFile: File, implicitContext: Option[String],
                              taggedFile: Option[File], escapeUnicode: Boolean) {
   def mergeContext(ctx: Option[String]): Option[String] = (implicitContext, ctx) match {
     case (None,    None)    => None

--- a/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/MessageLocation.scala
+++ b/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/MessageLocation.scala
@@ -16,16 +16,23 @@
 
 package ru.makkarpov.scalingua.pofile
 
+import java.io.File
+
 object MessageLocation {
   implicit case object LocationOrdering extends Ordering[MessageLocation] {
-    override def compare(x: MessageLocation, y: MessageLocation): Int =
-      x.file.compareToIgnoreCase(y.file) match {
+    override def compare(x: MessageLocation, y: MessageLocation): Int = {
+      //fs independent comparison
+      val r = x.file.toString.compareTo(y.file.toString) match {
         case 0 => x.line.compare(y.line)
         case x => x
       }
+      r
+    }
   }
 
-  def apply(file: String): MessageLocation = MessageLocation(file, -1)
+  def apply(file: String): MessageLocation = MessageLocation(new File(file), -1)
 }
 
-case class MessageLocation(file: String, line: Int)
+case class MessageLocation(file: File, line: Int) {
+  def fileString: String = file.toString.replaceAllLiterally("""\""", "/")
+}

--- a/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/NewLinePrintWriter.scala
+++ b/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/NewLinePrintWriter.scala
@@ -1,0 +1,15 @@
+package ru.makkarpov.scalingua.pofile
+
+import java.io.{PrintWriter, Writer}
+
+//uses system independent new lines
+class NewLinePrintWriter(out: Writer, autoFlush: Boolean)
+  extends PrintWriter(out, autoFlush) {
+  def this(out: Writer) = this(out, false)
+
+  override def println() {
+    print("\n")
+    if (autoFlush) flush()
+  }
+}
+

--- a/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
+++ b/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
@@ -52,8 +52,8 @@ object PoFile {
     parser.parse().value.asInstanceOf[Seq[Message]]
   }
 
-  def update(f: File, messages: Iterator[Message], escapeUnicode: Boolean = true): Unit = {
-    val output = new PrintWriter(new OutputStreamWriter(new FileOutputStream(f), encoding), false)
+  def update(f: File, messages: Seq[Message], escapeUnicode: Boolean = true): Unit = {
+    val output = new NewLinePrintWriter(new OutputStreamWriter(new FileOutputStream(f), encoding), false)
     try {
       output.println(headerComment(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())))
       output.println()
@@ -72,11 +72,11 @@ object PoFile {
         for (s <- m.header.extractedComments)
           output.println(s"#. $s")
 
-        for (s <- m.header.locations)
+        for (s <- m.header.locations.sorted)
           if (s.line < 0)
-            output.println(s"#: ${s.file}")
+            output.println(s"#: ${s.fileString}")
           else
-            output.println(s"#: ${s.file}:${s.line}")
+            output.println(s"#: ${s.fileString}:${s.line}")
 
         if (m.header.flags.nonEmpty)
           output.println(s"#, " + m.header.flags.map(_.toString).mkString(", "))

--- a/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/parse/MutableHeader.scala
+++ b/scalingua/src/main/scala/ru/makkarpov/scalingua/pofile/parse/MutableHeader.scala
@@ -1,7 +1,8 @@
 package ru.makkarpov.scalingua.pofile.parse
 
-import java_cup.runtime.ComplexSymbolFactory.Location
+import java.io.File
 
+import java_cup.runtime.ComplexSymbolFactory.Location
 import ru.makkarpov.scalingua.pofile.{MessageFlag, MessageHeader, MessageLocation, PoFile}
 
 import scala.collection.mutable
@@ -37,9 +38,9 @@ class MutableHeader {
             case _: NumberFormatException => throw ParserException(left, right, "cannot parse line number")
           }
 
-        locations += MessageLocation(file, line.toInt)
+        locations += MessageLocation(new File(file), line.toInt)
       } else {
-        locations += MessageLocation(str, -1)
+        locations += MessageLocation(new File(str), -1)
       }
 
     case ',' =>

--- a/scalingua/src/test/scala/ru/makkarpov/scalingua/test/PoFileTest.scala
+++ b/scalingua/src/test/scala/ru/makkarpov/scalingua/test/PoFileTest.scala
@@ -241,7 +241,7 @@ class PoFileTest extends FlatSpec with Matchers {
 
   it should "parse complex examples" in {
     t(
-      """#: x\test.scala:10
+      """#: x/test.scala:10
         |#: y/file.scala:20
         |#  A sample string
         |#. Should be translated

--- a/scalingua/src/test/scala/ru/makkarpov/scalingua/test/PoFileTest.scala
+++ b/scalingua/src/test/scala/ru/makkarpov/scalingua/test/PoFileTest.scala
@@ -16,7 +16,7 @@
 
 package ru.makkarpov.scalingua.test
 
-import java.io.ByteArrayInputStream
+import java.io.{ByteArrayInputStream, File}
 import java.nio.charset.StandardCharsets
 
 import org.scalatest.{FlatSpec, Matchers}
@@ -67,7 +67,7 @@ class PoFileTest extends FlatSpec with Matchers {
 
   it should "parse singular forms" in {
     t("""#  comment
-        |#: file.scala:20
+        |#: x/file.scala:20
         |#, fuzzy
         |#. tr comment
         |msgid "test"
@@ -82,7 +82,7 @@ class PoFileTest extends FlatSpec with Matchers {
           header = MessageHeader(
             Seq("comment"),
             Seq("tr comment"),
-            Seq(MessageLocation("file.scala", 20)),
+            Seq(MessageLocation(new File("x/file.scala"), 20)),
             MessageFlag.ValueSet(MessageFlag.Fuzzy),
             None
           ),
@@ -241,8 +241,8 @@ class PoFileTest extends FlatSpec with Matchers {
 
   it should "parse complex examples" in {
     t(
-      """#: test.scala:10
-        |#: file.scala:20
+      """#: x\test.scala:10
+        |#: y/file.scala:20
         |#  A sample string
         |#. Should be translated
         |#, fuzzy
@@ -266,7 +266,7 @@ class PoFileTest extends FlatSpec with Matchers {
           header = MessageHeader(
             comments = Seq("A sample string"),
             extractedComments = Seq("Should be translated"),
-            locations = Seq( MessageLocation("test.scala", 10), MessageLocation("file.scala", 20) ),
+            locations = Seq( MessageLocation(new File("x/test.scala"), 10), MessageLocation(new File("y/file.scala"), 20) ),
             flags = MessageFlag.ValueSet(MessageFlag.Fuzzy),
             tag = None
           ),
@@ -280,7 +280,7 @@ class PoFileTest extends FlatSpec with Matchers {
           )
         ),
         Message.Singular(
-          header = MessageHeader(Nil, Nil, Seq( MessageLocation("x.scala", 25) ), MessageFlag.ValueSet.empty, None),
+          header = MessageHeader(Nil, Nil, Seq( MessageLocation(new File("x.scala"), 25) ), MessageFlag.ValueSet.empty, None),
           context = None,
           message = MultipartString("Hello, world!"),
           translation = MultipartString("Привет, мир!")


### PR DESCRIPTION
This fixes line and path separators to UNIX standard to ensure the generated files are consistent across developers.
And also accidentally fixes locations ordering in generated files and running scripted tests on windows.
Apologies for mixed concerns.