### PR TITLE
#16 Allow header comment configuration

### DIFF
--- a/scalingua/shared/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
+++ b/scalingua/shared/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
@@ -52,10 +52,12 @@ object PoFile {
     parser.parse().value.asInstanceOf[Seq[Message]]
   }
 
-  def update(f: File, messages: Seq[Message], escapeUnicode: Boolean = true): Unit = {
+  def update(f: File, messages: Seq[Message], escapeUnicode: Boolean = true, includeHeaderComment: Boolean = true): Unit = {
     val output = new NewLinePrintWriter(new OutputStreamWriter(new FileOutputStream(f), encoding), false)
     try {
-      output.println(headerComment(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())))
+      if (includeHeaderComment) {
+        output.println(headerComment(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())))
+      }
       output.println()
 
       def printEntry(s: String, m: MultipartString): Unit = {


### PR DESCRIPTION
Skip adding `headerComment` when we do not need them.
Introduced a new configuration option (added as s third parameter to the update function) so it is not a breaking change. + option is true by default  - keep current behavior. 