### PR TITLE
Fix: add empty line after header comment only

### DIFF
--- a/scalingua/shared/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
+++ b/scalingua/shared/src/main/scala/ru/makkarpov/scalingua/pofile/PoFile.scala
@@ -57,8 +57,8 @@ object PoFile {
     try {
       if (includeHeaderComment) {
         output.println(headerComment(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date())))
+        output.println()
       }
-      output.println()
 
       def printEntry(s: String, m: MultipartString): Unit = {
         output.print(s + " ")


### PR DESCRIPTION
@makkarpov 👋 
I missed one thing in my previous PR. 
In case if we omit header comment we do not need empty line at the beginning:
### Before
```

msgid ""
msgstr ""
```


### After
```
msgid ""
msgstr ""
```
