### PR TITLE
Update: sbt, scalajs, scala2.12, scala2.13, play. Add: twirl module, native and sjs cross builds. Remove: scala2.11

### DIFF
--- a/core/src/main/scala/ru/makkarpov/scalingua/OutputFormat.scala
+++ b/core/src/main/scala/ru/makkarpov/scalingua/OutputFormat.scala
@@ -20,7 +20,7 @@ object OutputFormat {
   /**
     * String interpolation format that does nothing at all it's already strings.
     */
-  implicit val StringFormat = new OutputFormat[String] {
+  implicit val StringFormat: OutputFormat[String] = new OutputFormat[String] {
     override def convert(s: String): String = s
     override def escape(s: String): String = s
   }

--- a/play/src/main/scala/ru/makkarpov/scalingua/play/I18n.scala
+++ b/play/src/main/scala/ru/makkarpov/scalingua/play/I18n.scala
@@ -18,38 +18,13 @@ package ru.makkarpov.scalingua.play
 
 import play.api.http.HeaderNames
 import play.api.mvc.RequestHeader
-import play.twirl.api.Html
 import ru.makkarpov.scalingua
 import ru.makkarpov.scalingua._
 
 import scala.language.experimental.macros
 import scala.language.implicitConversions
 
-trait I18n extends scalingua.I18n {
-  type LHtml = LValue[Html]
-
-  implicit val htmlOutputFormat = new OutputFormat[Html] {
-    override def convert(s: String): Html = Html(s)
-
-    override def escape(s: String): String = {
-      val ret = new StringBuilder
-      var i = 0
-      ret.sizeHint(s.length)
-      while (i < s.length) {
-        s.charAt(i) match {
-          case '<' => ret.append("&lt;")
-          case '>' => ret.append("&gt;")
-          case '"' => ret.append("&quot;")
-          case '\'' => ret.append("&#x27;")
-          case '&' => ret.append("&amp;")
-          case c => ret += c
-        }
-        i += 1
-      }
-      ret.result()
-    }
-  }
-
+trait I18n extends scalingua.twirl.I18n {
   // The conversion from `RequestHeader` to `LanguageId` will imply information loss:
   // Suppose browser sent the following language precedence list `xx_YY`, `zz_WW`, `en_US`.
   // This conversion will have no information about available languages, so it will result in
@@ -59,37 +34,6 @@ trait I18n extends scalingua.I18n {
 
   implicit def requestHeader2Language(implicit rq: RequestHeader, msg: Messages): Language =
     rq.headers.get(HeaderNames.ACCEPT_LANGUAGE).map(PlayUtils.languageFromAccept).getOrElse(Language.English)
-
-  implicit def stringContext2Interpolator1(sc: StringContext): PlayUtils.StringInterpolator =
-    new PlayUtils.StringInterpolator(sc)
-
-  def th(msg: String, args: (String, Any)*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-    macro Macros.singular[Html]
-
-  def lth(msg: String, args: (String, Any)*)(implicit outputFormat: OutputFormat[Html]): LHtml =
-    macro Macros.lazySingular[Html]
-
-  def tch(ctx: String, msg: String, args: (String, Any)*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-    macro Macros.singularCtx[Html]
-
-  def ltch(ctx: String, msg: String, args: (String, Any)*)(implicit outputFormat: OutputFormat[Html]): LHtml =
-    macro Macros.lazySingularCtx[Html]
-
-  def p(msg: String, msgPlural: String, n: Long, args: (String, Any)*)
-       (implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-    macro Macros.plural[Html]
-
-  def lp(msg: String, msgPlural: String, n: Long, args: (String, Any)*)
-        (implicit outputFormat: OutputFormat[Html]): LHtml =
-    macro Macros.lazyPlural[Html]
-
-  def pc(ctx: String, msg: String, msgPlural: String, n: Long, args: (String, Any)*)
-        (implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-    macro Macros.pluralCtx[Html]
-
-  def lpc(ctx: String, msg: String, msgPlural: String, n: Long, args: (String, Any)*)
-         (implicit outputFormat: OutputFormat[Html]): LHtml =
-    macro Macros.lazyPluralCtx[Html]
 }
 
 object I18n extends I18n

--- a/play/src/main/scala/ru/makkarpov/scalingua/play/PlayUtils.scala
+++ b/play/src/main/scala/ru/makkarpov/scalingua/play/PlayUtils.scala
@@ -17,26 +17,11 @@
 package ru.makkarpov.scalingua.play
 
 import play.api.mvc.RequestHeader
-import play.twirl.api.Html
 import ru.makkarpov.scalingua._
 
 import scala.language.experimental.macros
 
 object PlayUtils {
-  class StringInterpolator(val sc: StringContext) extends AnyVal {
-    def h(args: Any*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-      macro Macros.interpolate[Html]
-
-    def lh(args: Any*)(implicit outputFormat: OutputFormat[Html]): LValue[Html] =
-      macro Macros.lazyInterpolate[Html]
-
-    def ph(args: Any*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
-      macro Macros.pluralInterpolate[Html]
-
-    def lph(args: Any*)(outputFormat: OutputFormat[Html]): LValue[Html] =
-      macro Macros.lazyPluralInterpolate[Html]
-  }
-
   // Modified to match only correct doubles
   private val qPattern = ";\\s*q=((?:[0-9]+\\.)?[0-9]+)".r
 

--- a/play/src/test/scala/ru/makkarpov/scalingua/play/test/PlayTest.scala
+++ b/play/src/test/scala/ru/makkarpov/scalingua/play/test/PlayTest.scala
@@ -22,13 +22,6 @@ import ru.makkarpov.scalingua.{Language, Messages, TaggedLanguage}
 import ru.makkarpov.scalingua.play.I18n._
 
 class PlayTest extends AnyFlatSpec with Matchers {
-  it should "handle HTML translations" in {
-    implicit val lang = Language.English
-    val x = "\"List<String>\""
-    h"A class <code>$x</code> can be used to provide simple list container".body shouldBe
-      "A class <code>&quot;List&lt;String&gt;&quot;</code> can be used to provide simple list container"
-  }
-
   it should "handle 'Accept' header" in {
     implicit val messages = new Messages(
       TaggedLanguage.Identity,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,10 @@ logLevel := Level.Warn
 resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.4.16")
 
 libraryDependencies ++= Seq(
   "de.jflex" % "jflex" % "1.6.1",

--- a/sbt-plugin/src/sbt-test/main/inline-scala-js/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/main/inline-scala-js/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 addSbtPlugin("ru.makkarpov" % "scalingua-sbt" % {
   val ver = System.getProperty("scalingua.version")
   if(ver == null) throw new RuntimeException("Scalingua version is not defined")

--- a/scalingua/shared/src/test/scala/ru/makkarpov/scalingua/test/CustomI18nTest.scala
+++ b/scalingua/shared/src/test/scala/ru/makkarpov/scalingua/test/CustomI18nTest.scala
@@ -25,7 +25,7 @@ import scala.language.experimental.macros
 class CustomI18nTest extends AnyFlatSpec with Matchers {
   case class CStr(s: String)
 
-  implicit val CStrFormat = new OutputFormat[CStr] {
+  implicit val CStrFormat: OutputFormat[CStr] = new OutputFormat[CStr] {
     override def convert(s: String): CStr = CStr(s"C{$s}")
     override def escape(s: String): String = s"[$s]"
   }
@@ -35,7 +35,7 @@ class CustomI18nTest extends AnyFlatSpec with Matchers {
       macro Macros.singular[CStr]
   }
 
-  implicit val mockLang = new MockLang("")
+  implicit val mockLang: MockLang = new MockLang("")
 
   import CustomI18n._
 

--- a/scalingua/shared/src/test/scala/ru/makkarpov/scalingua/test/MacroTest.scala
+++ b/scalingua/shared/src/test/scala/ru/makkarpov/scalingua/test/MacroTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers.should.Matchers
 import ru.makkarpov.scalingua.I18n._
 
 class MacroTest extends AnyFlatSpec with Matchers {
-  implicit val mockLang = new MockLang("")
+  implicit val mockLang: MockLang = new MockLang("")
 
   it should "handle string interpolations" in {
     t"Hello, world!" shouldBe "{s:Hello, world!}"

--- a/twirl/shared/src/main/scala/ru/makkarpov/scalingua/twirl/I18n.scala
+++ b/twirl/shared/src/main/scala/ru/makkarpov/scalingua/twirl/I18n.scala
@@ -1,0 +1,83 @@
+/******************************************************************************
+ * Copyright © 2016 Maxim Karpov                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *     http://www.apache.org/licenses/LICENSE-2.0                             *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ ******************************************************************************/
+
+package ru.makkarpov.scalingua.twirl
+
+import play.twirl.api.Html
+import ru.makkarpov.scalingua
+import ru.makkarpov.scalingua._
+
+import scala.language.experimental.macros
+import scala.language.implicitConversions
+
+trait I18n extends scalingua.I18n {
+  type LHtml = LValue[Html]
+
+  implicit val htmlOutputFormat: OutputFormat[Html] = new OutputFormat[Html] {
+    override def convert(s: String): Html = Html(s)
+
+    override def escape(s: String): String = {
+      val ret = new StringBuilder
+      var i = 0
+      ret.sizeHint(s.length)
+      while (i < s.length) {
+        s.charAt(i) match {
+          case '<' => ret.append("&lt;")
+          case '>' => ret.append("&gt;")
+          case '"' => ret.append("&quot;")
+          case '\'' => ret.append("&#x27;")
+          case '&' => ret.append("&amp;")
+          case c => ret += c
+        }
+        i += 1
+      }
+      ret.result()
+    }
+  }
+
+  implicit def stringContext2Interpolator1(sc: StringContext): PlayUtils.StringInterpolator =
+    new PlayUtils.StringInterpolator(sc)
+
+  def th(msg: String, args: (String, Any)*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+    macro Macros.singular[Html]
+
+  def lth(msg: String, args: (String, Any)*)(implicit outputFormat: OutputFormat[Html]): LHtml =
+    macro Macros.lazySingular[Html]
+
+  def tch(ctx: String, msg: String, args: (String, Any)*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+    macro Macros.singularCtx[Html]
+
+  def ltch(ctx: String, msg: String, args: (String, Any)*)(implicit outputFormat: OutputFormat[Html]): LHtml =
+    macro Macros.lazySingularCtx[Html]
+
+  def p(msg: String, msgPlural: String, n: Long, args: (String, Any)*)
+       (implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+    macro Macros.plural[Html]
+
+  def lp(msg: String, msgPlural: String, n: Long, args: (String, Any)*)
+        (implicit outputFormat: OutputFormat[Html]): LHtml =
+    macro Macros.lazyPlural[Html]
+
+  def pc(ctx: String, msg: String, msgPlural: String, n: Long, args: (String, Any)*)
+        (implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+    macro Macros.pluralCtx[Html]
+
+  def lpc(ctx: String, msg: String, msgPlural: String, n: Long, args: (String, Any)*)
+         (implicit outputFormat: OutputFormat[Html]): LHtml =
+    macro Macros.lazyPluralCtx[Html]
+}
+
+object I18n extends I18n

--- a/twirl/shared/src/main/scala/ru/makkarpov/scalingua/twirl/PlayUtils.scala
+++ b/twirl/shared/src/main/scala/ru/makkarpov/scalingua/twirl/PlayUtils.scala
@@ -14,19 +14,25 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-package ru.makkarpov.scalingua
+package ru.makkarpov.scalingua.twirl
 
-object Compat {
-  type Context = scala.reflect.macros.Context
-  def prettyPrint(c: Context)(e: c.Tree): String = c.universe.show(e)
-  def termName(c: Context)(s: String): c.TermName = c.universe.newTermName(c.fresh(s))
-  def typecheck(c: Context)(e: c.Tree): c.Tree = c.typeCheck(e)
+import play.twirl.api.Html
+import ru.makkarpov.scalingua._
 
-  def processEscapes(s: String) = scala.StringContext.treatEscapes(s)
+import scala.language.experimental.macros
 
-  implicit class MutSetOps[A](s: scala.collection.mutable.Set[A]) {
-    def filterInPlace(p: A => Boolean) = s.retain(p)
+object PlayUtils {
+  class StringInterpolator(val sc: StringContext) extends AnyVal {
+    def h(args: Any*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+      macro Macros.interpolate[Html]
+
+    def lh(args: Any*)(implicit outputFormat: OutputFormat[Html]): LValue[Html] =
+      macro Macros.lazyInterpolate[Html]
+
+    def ph(args: Any*)(implicit lang: Language, outputFormat: OutputFormat[Html]): Html =
+      macro Macros.pluralInterpolate[Html]
+
+    def lph(args: Any*)(outputFormat: OutputFormat[Html]): LValue[Html] =
+      macro Macros.lazyPluralInterpolate[Html]
   }
-
-  val CollectionConverters = scala.collection.JavaConverters
 }

--- a/twirl/shared/src/test/scala/ru/makkarpov/scalingua/twirl/test/PlayTest.scala
+++ b/twirl/shared/src/test/scala/ru/makkarpov/scalingua/twirl/test/PlayTest.scala
@@ -14,23 +14,18 @@
  * limitations under the License.                                             *
  ******************************************************************************/
 
-package ru.makkarpov.scalingua
+package ru.makkarpov.scalingua.twirl.test
 
-import ru.makkarpov.scalingua.extract.MessageExtractor
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ru.makkarpov.scalingua.{Language, Messages, TaggedLanguage}
+import ru.makkarpov.scalingua.twirl.I18n._
 
-import scala.reflect.macros.whitebox
-
-object Compat {
-  type Context = whitebox.Context
-  def prettyPrint(c: Context)(e: c.Tree): String = c.universe.showCode(e)
-  def termName(c: Context)(s: String): c.TermName = c.universe.TermName(c.freshName(s))
-  def typecheck(c: Context)(e: c.Tree): c.Tree = c.typecheck(e)
-
-  def processEscapes(s: String) = scala.StringContext.processEscapes(s)
-
-  implicit class MutSetOps[A](s: scala.collection.mutable.Set[A]) {
-    def filterInPlace(p: A => Boolean) = s.retain(p)
+class PlayTest extends AnyFlatSpec with Matchers {
+  it should "handle HTML translations" in {
+    implicit val lang = Language.English
+    val x = "\"List<String>\""
+    h"A class <code>$x</code> can be used to provide simple list container".body shouldBe
+      "A class <code>&quot;List&lt;String&gt;&quot;</code> can be used to provide simple list container"
   }
-
-  val CollectionConverters = scala.collection.JavaConverters
 }


### PR DESCRIPTION
The most notable change is update to play3 and introduction of separate twirl module (available for jvm and js).
No direct support for scala3 yet.